### PR TITLE
InformationHost

### DIFF
--- a/MagicPi/models/HostInformation.py
+++ b/MagicPi/models/HostInformation.py
@@ -20,7 +20,10 @@ class HostInformation:
 
     # Retourne les informations de l'interface
     def getInfoForInterface(self,interface):
-        return self.interfaces[interface][self.netIfaces.AF_INET];
+        try:
+            return self.interfaces[interface][self.netIfaces.AF_INET];
+        except:
+            return False
 
     #retourne le CIDR
     def getCidrFromIp(self,ip):

--- a/MagicPi/models/HostInformation.py
+++ b/MagicPi/models/HostInformation.py
@@ -25,3 +25,10 @@ class HostInformation:
     #retourne le CIDR
     def getCidrFromIp(self,ip):
         return '/'+str('.'.join([bin(int(x)+256)[3:] for x in ip.split('.')]).count('1'));
+
+    # Retourne le gateWay de l'interface si possible, false sinon (default est une valeur possible)
+    def getGateWayForInterface(self,interface):
+        for gateway_ip, network_card, is_default in self.netIfaces.gateways()[self.netIfaces.AF_INET]:
+            if network_card == interface:
+                return gateway_ip
+        return False;


### PR DESCRIPTION
Ajout de la methode getGateWayForInterface : 
- Prend l'interface en argument
- Retourne le gateway si l'interface est connecté
- Retourne False sinon
