### PR TITLE
Pathos | Correction du repo

### DIFF
--- a/requirements
+++ b/requirements
@@ -1,4 +1,4 @@
 scapy
 tendo
 netifaces
-pathos
+git+https://github.com/uqfoundation/pathos


### PR DESCRIPTION
pathos n'est pas a joutr sur pip, on prend la version repo
