### PR TITLE
HostInformation | recuperation de l'ip public

### DIFF
--- a/MagicPi/models/HostInformation.py
+++ b/MagicPi/models/HostInformation.py
@@ -9,6 +9,31 @@ class HostInformation:
         self.netIfaces = Environement.getImport("netifaces");
         self.loadInformation();
 
+    # Recupere, si possible, l'ip publique lie a l'interface donnee
+    def getPublicIp(self,interface):
+        # On recupere les import
+        PyCurl = self.env.getImport('pycurl');
+        stringIo = self.env.getImport('StringIO')
+        # stringIO permettra a curl de stocker le resultat plutot que de l'afficher
+        tmpStorage = stringIo.StringIO()
+
+        # On intialise curl
+        curlConn = PyCurl.Curl();
+        curlConn.setopt(PyCurl.URL, '52.28.249.93/ip'); # retourne l'ip publique (ipinfo.io)
+        curlConn.setopt(PyCurl.CONNECTTIMEOUT, 5) # On met un timeout de 5 secondes
+        curlConn.setopt(PyCurl.INTERFACE, interface) # On map avec l'interface
+        curlConn.setopt(PyCurl.WRITEFUNCTION, tmpStorage.write) # On redirige le flux vers stringIO
+        try :
+            # On execute et on recupere le retour
+            curlConn.perform();
+            retour = tmpStorage.getvalue();
+        except:
+            # Sinon le retour est False
+            retour = False;
+        # On ferme la connexion, et on fais le retour
+        curlConn.close();
+        return retour;
+
     # Methode appele a la construction, instancie les parametres de l'interface
     def loadInformation(self):
         for interface_en_cours in self.netIfaces.interfaces() :


### PR DESCRIPTION
Ajout de la methode getPublicIp :
  Retourne l'ip public de l'interface passé en argument
  Retourne False sinon
